### PR TITLE
Stab in the dark at fixing the global config issue.

### DIFF
--- a/config.1password.yaml
+++ b/config.1password.yaml
@@ -1,4 +1,33 @@
 #ddev-generated
 hooks:
+  pre-start:
+    - exec-host: |
+        # Check to see if our config flag file is present
+        if [ -f ~/.ddev/1password_enabled ]; then
+          echo "1Password integration enabled."
+          if [ ! -f ./.ddev/docker-compose.1password.yaml ]; then
+            echo "Adding 1Password docker-compose file to project."
+            cat <<EOF > ./.ddev/docker-compose.1password.yaml
+            #ddev-generated
+            services:
+              web:
+                volumes:
+                  - type: bind
+                    source: /run/host-services/ssh-auth.sock
+                    target: /run/host-services/ssh-auth.sock
+                environment:
+                  - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+        EOF
+          fi
+        else
+          echo "1Password integration disabled."
+            if [ -f ./.ddev/docker-compose.1password.yaml ]; then
+                // Check that the file contains '#ddev-generated' to avoid deleting non-ddev files
+                if grep -q '#ddev-generated' ./.ddev/docker-compose.1password.yaml; then
+                    echo "Removing 1Password docker-compose file from project."
+                    rm ./.ddev/docker-compose.1password.yaml
+                fi
+            fi
+        fi
   post-start:
     - exec: "sudo chmod o+rw /run/host-services/ssh-auth.sock"

--- a/install.yaml
+++ b/install.yaml
@@ -1,8 +1,8 @@
 name: 1password
 
 project_files:
-  - docker-compose.1password.yaml
   - config.1password.yaml
+  - project/.gitignore
 
 global_files:
   - commands/host/1password

--- a/project/.gitignore
+++ b/project/.gitignore
@@ -1,0 +1,1 @@
+/docker-compose.1password.yaml


### PR DESCRIPTION
## The Issue

- Fixes #3

That we can't disable this plugin other than removing the add-on from the project.

## How This PR Solves The Issue

Tries to make it that it's going to look for the presence of a file in the home directory.

So with this add-on, basically nothing changes unless someone has the:

`~/.ddev/1password_enabled`

file on their machine, and then in that case, the docker-compose service is added, and the ssh agent is all wired up.

If they don't, then it doesn't. This means that the add-on can be installed and in the project, but not be active by default.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/anotherjames/ddev-1password/tarball/refs/pull/7/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
